### PR TITLE
Update README to use functioning Laravel 4 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 If you're going to use this package with Laravel 4, make sure to include the Laravel 4 version: 
 ```js
 "require": {
-    "anouar/paypalpayment": "1.0"
+    "anouar/paypalpayment": "dev-l4"
 }
 ```
 laravel-paypalpayment


### PR DESCRIPTION
Package version `1.0` for use with Laravel 4 uses an outdated Paypal SDK (v0.13.2). Until this package version is updated, use `dev-l4` as version for composer install. See https://github.com/xroot/laravel-paypalpayment/pull/56#issuecomment-166706288 for brief discussion.
